### PR TITLE
test: Add recruitment controller and service test

### DIFF
--- a/src/main/java/com/wanted/preonboarding/applicant/entity/Applicant.java
+++ b/src/main/java/com/wanted/preonboarding/applicant/entity/Applicant.java
@@ -2,10 +2,16 @@ package com.wanted.preonboarding.applicant.entity;
 
 import com.wanted.preonboarding.common.BaseTime;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
-import java.util.HashSet;
+import java.util.Set;
 
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Entity
 public class Applicant extends BaseTime {
 
@@ -17,7 +23,7 @@ public class Applicant extends BaseTime {
     private String name;
 
     @OneToMany(mappedBy = "applicant")
-    private HashSet<Application> applications = new HashSet<>();
+    private Set<Application> applications;
 
     @Column(name = "is_deleted")
     @ColumnDefault("'N'")

--- a/src/main/java/com/wanted/preonboarding/recruitment/RecruitmentController.java
+++ b/src/main/java/com/wanted/preonboarding/recruitment/RecruitmentController.java
@@ -35,7 +35,7 @@ public class RecruitmentController {
 
     //요구사항 2번 - 채용공고 수정
     @PutMapping("/{recruitmentId}")
-    public ResponseEntity<CommonResponse> putRecruitment(RecruitmentUpdateDto recruitUpdateDto,
+    public ResponseEntity<CommonResponse> putRecruitment(@RequestBody RecruitmentUpdateDto recruitUpdateDto,
                                                          @PathVariable Long recruitmentId) {
         Long modifiedId = recruitService.modifyRecruitment(recruitUpdateDto, recruitmentId);
         URI location = ServletUriComponentsBuilder

--- a/src/main/java/com/wanted/preonboarding/recruitment/RecruitmentService.java
+++ b/src/main/java/com/wanted/preonboarding/recruitment/RecruitmentService.java
@@ -40,7 +40,7 @@ public class RecruitmentService {
     public void removeRecruitment(Long recruitmentId) {
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId).orElseThrow(
                 () -> new CompanyException(CompanyErrorCode.COMPANY_NOT_FOUND));
-        recruitmentRepository.delete(recruitment);
+        recruitment.setIsDeleted("Y");
     }
 
 }

--- a/src/test/java/com/wanted/preonboarding/config/TestConfig.java
+++ b/src/test/java/com/wanted/preonboarding/config/TestConfig.java
@@ -1,0 +1,83 @@
+package com.wanted.preonboarding.config;
+
+import com.wanted.preonboarding.applicant.entity.Applicant;
+import com.wanted.preonboarding.applicant.entity.Application;
+import com.wanted.preonboarding.applicant.repository.ApplicantRepository;
+import com.wanted.preonboarding.applicant.repository.ApplicationRepository;
+import com.wanted.preonboarding.common.Tech;
+import com.wanted.preonboarding.recruitment.entity.Company;
+import com.wanted.preonboarding.recruitment.entity.Recruitment;
+import com.wanted.preonboarding.recruitment.repository.CompanyRepository;
+import com.wanted.preonboarding.recruitment.repository.RecruitmentRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@TestConfiguration
+public class TestConfig {
+
+    private final CompanyRepository companyRepository;
+    private final RecruitmentRepository recruitmentRepository;
+    private final ApplicantRepository applicantRepository;
+    private final ApplicationRepository applicationRepository;
+    Company company;
+    Recruitment recruitment;
+    Applicant applicant;
+    Application application;
+
+    @PostConstruct
+    void insertDummyData() {
+        createCompanyDummyData();
+        createRecruitmentDummyData();
+        createApplicantDummyData();
+        createApplicationDummyData();
+    }
+
+    void createCompanyDummyData() {
+        company = Company.builder()
+                .name("원티드")
+                .country("대한민국")
+                .region("서울시 송파구")
+                .build();
+        companyRepository.save(company);
+    }
+
+    void createRecruitmentDummyData() {
+        recruitment = Recruitment.builder()
+                .position("주니어 백엔드 개발자")
+                .company(company)
+                .signingBonus(500_000)
+                .techStack(Tech.isTechExist("Spring"))
+                .content("많은 지원바랍니다.")
+                .build();
+        recruitmentRepository.save(recruitment);
+    }
+
+    void createApplicantDummyData() {
+        applicant = Applicant.builder()
+                .name("김원티드")
+                .build();
+        applicantRepository.save(applicant);
+    }
+
+    void createApplicationDummyData() {
+        application = Application.builder()
+                .applicant(applicant)
+                .recruitment(recruitment)
+                .build();
+        applicationRepository.save(application);
+    }
+
+    @PreDestroy
+    void deleteDummyData() {
+        companyRepository.deleteAll();
+        recruitmentRepository.deleteAll();
+        applicantRepository.deleteAll();
+        applicationRepository.deleteAll();
+    }
+
+}

--- a/src/test/java/com/wanted/preonboarding/recruitment/RecruitmentControllerTest.java
+++ b/src/test/java/com/wanted/preonboarding/recruitment/RecruitmentControllerTest.java
@@ -1,0 +1,91 @@
+package com.wanted.preonboarding.recruitment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.preonboarding.config.TestConfig;
+import com.wanted.preonboarding.recruitment.dto.RecruitmentRegisterDto;
+import com.wanted.preonboarding.recruitment.dto.RecruitmentUpdateDto;
+import com.wanted.preonboarding.recruitment.entity.Company;
+import com.wanted.preonboarding.recruitment.entity.Recruitment;
+import com.wanted.preonboarding.recruitment.repository.CompanyRepository;
+import com.wanted.preonboarding.recruitment.repository.RecruitmentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("채용공고 컨트롤러 테스트")
+@Import({TestConfig.class})
+@AutoConfigureMockMvc
+@SpringBootTest
+class RecruitmentControllerTest {
+
+    @Autowired
+    ObjectMapper mapper;
+    @Autowired
+    MockMvc mvc;
+    @Autowired
+    CompanyRepository companyRepository;
+    @Autowired
+    RecruitmentRepository recruitmentRepository;
+
+    Company company;
+    Recruitment recruitment;
+
+    private static final String BASE_URL = "/recruitment";
+
+    @BeforeEach
+    void getTestCompany() {
+        company = companyRepository.findAll().get(0);
+        recruitment = recruitmentRepository.findAll().get(0);
+    }
+
+    @Test
+    @DisplayName("채용공고 저장 요청 테스트")
+    void postRecruitmentTest() throws Exception {
+        String body = mapper.writeValueAsString(RecruitmentRegisterDto.builder()
+                .companyId(company.getId())
+                .position("백엔드 주니어 개발자")
+                .signingBonus(0)
+                .techStack("Spring")
+                .content("많은 지원 바랍니다.")
+                .build());
+
+        mvc.perform(post(BASE_URL)
+                        .content(body)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+    }
+
+
+    @Test
+    @DisplayName("채용공고 수정 요청 테스트")
+    void putRecruitmentTest() throws Exception {
+        String body = mapper.writeValueAsString(RecruitmentUpdateDto.builder()
+                .position("백엔드 시니어 개발자")
+                .signingBonus(1_000_000)
+                .techStack("Spring")
+                .content("업계 최고 대우 예정입니다.")
+                .build());
+        mvc.perform(put(BASE_URL + "/" + recruitment.getId())
+                        .content(body)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("채용공고 삭제 요청 테스트")
+    void deleteRecruitmentTest() throws Exception {
+        mvc.perform(delete(BASE_URL + "/" + recruitment.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/wanted/preonboarding/recruitment/RecruitmentServiceTest.java
+++ b/src/test/java/com/wanted/preonboarding/recruitment/RecruitmentServiceTest.java
@@ -1,6 +1,7 @@
 package com.wanted.preonboarding.recruitment;
 
 import com.wanted.preonboarding.common.Tech;
+import com.wanted.preonboarding.config.TestConfig;
 import com.wanted.preonboarding.recruitment.dto.RecruitmentRegisterDto;
 import com.wanted.preonboarding.recruitment.dto.RecruitmentUpdateDto;
 import com.wanted.preonboarding.recruitment.entity.Company;
@@ -11,11 +12,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
+@Import({TestConfig.class})
 @DisplayName("채용공고 Service 클래스 테스트")
 @SpringBootTest
 class RecruitmentServiceTest {
@@ -27,25 +30,19 @@ class RecruitmentServiceTest {
     @Autowired
     private RecruitmentService recruitmentService;
 
-
     Company company;
+
     @BeforeEach
     void getTestCompany() {
-        Company testcompany = Company.builder()
-                .name("원티드")
-                .country("대한민국")
-                .region("서울시 송파구")
-                .build();
-        companyRepository.save(testcompany);
         company = companyRepository.findAll().get(0);
     }
 
     @Test
     @DisplayName("채용공고 저장 테스트")
     void addRecruitmentTest() {
+
         //given
         int originalRepositorySize = recruitmentRepository.findAll().size();
-
         RecruitmentRegisterDto recruitmentRegisterDto = RecruitmentRegisterDto.builder()
                 .position("백엔드 주니어 개발자")
                 .companyId(company.getId())
@@ -53,9 +50,9 @@ class RecruitmentServiceTest {
                 .techStack("Spring")
                 .content("많은 지원 바랍니다.")
                 .build();
-        recruitmentService.addRecruitment(recruitmentRegisterDto);
 
         //when
+        recruitmentService.addRecruitment(recruitmentRegisterDto);
 
         //then
         assertThat(recruitmentRepository.findAll().size()).isEqualTo(originalRepositorySize + 1);
@@ -87,6 +84,27 @@ class RecruitmentServiceTest {
         //then
         assertThat(recruitmentRepository.findById(savedRecruitmentId).get().getPosition())
                 .isNotEqualTo(originalPosition);
+    }
+
+    @Test
+    @DisplayName("채용공고 삭제 테스트")
+    void deleteRecruitmentTest() {
+        //given
+        RecruitmentRegisterDto recruitmentRegisterDto = RecruitmentRegisterDto.builder()
+                .position("백엔드 주니어 개발자")
+                .companyId(company.getId())
+                .signingBonus(5_000_000)
+                .techStack("Spring")
+                .content("많은 지원 바랍니다.")
+                .build();
+        Long savedRecruitmentId = recruitmentService.addRecruitment(recruitmentRegisterDto);
+        int originalSize = recruitmentRepository.findAll().size();
+
+        //when
+        recruitmentService.removeRecruitment(savedRecruitmentId);
+
+        //then
+        assertThat(recruitmentRepository.findAll().size()).isEqualTo(originalSize - 1);
     }
 
 }


### PR DESCRIPTION
- 채용공고 controller 와 service 의 테스트 코드 추가
- 테스트용 테이블을 초기화하는 `TestConfig` 추가
- 채용공고의 삭제하는 부분을 `삭제` -> `isDeleted` 필드를 수정하는 것으로 변경
- 컨트롤러의 채용공고 수정 메소드의 파라미터에 빠진 파라미터 추가
- 지원자 엔티티의 `applications` 필드의 타입을 `HashSet` -> `Set` 으로 변경
   - JPA 오류 발생 